### PR TITLE
Fixed a bug where the window was minimized when running the program

### DIFF
--- a/IniSettings.cpp
+++ b/IniSettings.cpp
@@ -107,7 +107,9 @@ void CIniSettings::RestoreWindowPos( LPCWSTR windowname, HWND hWnd, UINT showCmd
     {
         if (wpl.showCmd == SW_HIDE)
             wpl.showCmd = SW_SHOWDEFAULT;
-        if ((wpl.showCmd == SW_MINIMIZE) || (wpl.showCmd == SW_SHOWMINNOACTIVE))
+        else if ((wpl.showCmd == SW_SHOWMINIMIZED) && (wpl.flags & WPF_RESTORETOMAXIMIZED))
+            wpl.showCmd = SW_SHOWMAXIMIZED;
+        else if ((wpl.showCmd == SW_SHOWMINIMIZED) || (wpl.showCmd == SW_MINIMIZE) || (wpl.showCmd == SW_SHOWMINNOACTIVE))
             wpl.showCmd = SW_RESTORE;
         if (showCmd)
             wpl.showCmd = showCmd;


### PR DESCRIPTION
Maximize the window first, then minimize the window and right click to close the program. Minimized state when the program starts again