### PR TITLE
translate between any languages multiple times

### DIFF
--- a/Language.h
+++ b/Language.h
@@ -50,5 +50,6 @@ private:
     static std::wstring  GetTranslatedString(const std::wstring& s, std::map<std::wstring, std::wstring>* pLangMap);
 
 private:
-    std::map<std::wstring, std::wstring> langmap;
+    std::map<std::wstring, std::wstring>        langmap;
+    static std::map<std::wstring, std::wstring> langmapBack;
 };


### PR DESCRIPTION
Users may mistakenly select the adjacent option, and then choose again.

Noticed and patched while I'm developing a new feature for [grepWin](https://github.com/stefankueng/grepWin).